### PR TITLE
Use signer when posting to gateway

### DIFF
--- a/brownie_safe.py
+++ b/brownie_safe.py
@@ -226,12 +226,15 @@ class BrownieSafeBase(metaclass=ABCMeta):
 
         See also https://github.com/gnosis/safe-cli/blob/master/safe_cli/api/gnosis_transaction.py
         """
-        signer = None
-        if not safe_tx.sorted_signers:
+        if safe_tx.signatures:
+            signature = safe_tx.signatures[0]
+            signer = safe_tx.signers[0]
+        else:
             signature, signer = self.sign_transaction(safe_tx)
+            signer = signer.address
 
         if self.use_gateway:
-            post_transaction_via_gateway(signer.address if signer is not None else safe_tx.signers[0], safe_tx, signature)
+            post_transaction_via_gateway(signer, safe_tx, signature)
         else:
             self.transaction_service.post_transaction(safe_tx)
 

--- a/brownie_safe.py
+++ b/brownie_safe.py
@@ -451,7 +451,7 @@ def safe_tx_to_json(sender, safe_tx, signature):
         'refundReceiver': safe_tx.refund_receiver,
         'nonce': str(safe_tx.safe_nonce),
         'sender': sender,
-        'signature': '0x' + signature.hex(),
+        'signature': signature.hex(),
         'origin': 'wavey-script'
     }
     return json_str

--- a/brownie_safe.py
+++ b/brownie_safe.py
@@ -228,7 +228,7 @@ class BrownieSafeBase(metaclass=ABCMeta):
         See also https://github.com/gnosis/safe-cli/blob/master/safe_cli/api/gnosis_transaction.py
         """
         if safe_tx.signatures:
-            signatures = SafeSignature.parse_signature(self.signatures, self.safe_tx_hash)
+            signatures = SafeSignature.parse_signature(safe_tx.signatures, safe_tx.safe_tx_hash)
             signature = signatures[0].signature
             signer = signatures[0].owner
         else:

--- a/brownie_safe.py
+++ b/brownie_safe.py
@@ -226,11 +226,12 @@ class BrownieSafeBase(metaclass=ABCMeta):
 
         See also https://github.com/gnosis/safe-cli/blob/master/safe_cli/api/gnosis_transaction.py
         """
+        signer = None
         if not safe_tx.sorted_signers:
             signature, signer = self.sign_transaction(safe_tx)
 
         if self.use_gateway:
-            post_transaction_via_gateway(signer.address, safe_tx, signature)
+            post_transaction_via_gateway(signer.address if signer is not None else safe_tx.signers[0], safe_tx, signature)
         else:
             self.transaction_service.post_transaction(safe_tx)
 

--- a/brownie_safe.py
+++ b/brownie_safe.py
@@ -21,6 +21,7 @@ from safe_eth.safe.multi_send import MultiSend, MultiSendOperation, MultiSendTx
 from safe_eth.safe.safe_tx import SafeTx
 from safe_eth.safe.signatures import signature_split, signature_to_bytes
 from safe_eth.safe.api import TransactionServiceApi
+from safe_eth.safe.safe_signature import SafeSignature
 from hexbytes import HexBytes
 from trezorlib import ethereum, tools, ui
 from trezorlib.client import TrezorClient
@@ -227,8 +228,9 @@ class BrownieSafeBase(metaclass=ABCMeta):
         See also https://github.com/gnosis/safe-cli/blob/master/safe_cli/api/gnosis_transaction.py
         """
         if safe_tx.signatures:
-            signature = safe_tx.signatures[0]
-            signer = safe_tx.signers[0]
+            signatures = SafeSignature.parse_signature(self.signatures, self.safe_tx_hash)
+            signature = signatures[0].signature
+            signer = signatures[0].owner
         else:
             signature, signer = self.sign_transaction(safe_tx)
             signer = signer.address


### PR DESCRIPTION
When posting a transaction to the gateway, if the transaction has signers), parse the signatures and use the first signer in the list